### PR TITLE
fix: correct VirSci arXiv ID (2505.00614 -> 2410.09403)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -194,7 +194,7 @@
         <div style="font-size:1.4rem;margin-bottom:10px;">🧬</div>
         <h3 style="font-size:1.05rem;font-weight:700;margin-bottom:8px;">VirSci</h3>
         <p style="color:var(--muted);font-size:.9rem;line-height:1.6;margin-bottom:16px;"><span id="t-virsci-desc">A multi-agent scientific deliberation system. Multiple AI personas with different research backgrounds debate a hypothesis, producing richer and more diverse research ideas than single-agent generation. Integrated into ARI's idea generation stage.</span></p>
-        <a href="https://arxiv.org/abs/2505.00614" target="_blank" style="font-size:.85rem;color:var(--blue-light);">arxiv.org/abs/2505.00614 →</a>
+        <a href="https://arxiv.org/abs/2410.09403" target="_blank" style="font-size:.85rem;color:var(--blue-light);">arxiv.org/abs/2410.09403 →</a>
       </div>
 
     </div>


### PR DESCRIPTION
Fixes incorrect arXiv ID for VirSci in homepage (`docs/index.html`).

`2505.00614` was a combinatorics math paper. The correct VirSci paper is [arXiv:2410.09403](https://arxiv.org/abs/2410.09403) (ACL 2025 Main).