### PR TITLE
macOSでのセットアップ

### DIFF
--- a/ari-core/ari/cli/__init__.py
+++ b/ari-core/ari/cli/__init__.py
@@ -15,6 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
+from dotenv import load_dotenv
 import typer
 from rich.console import Console
 from rich.panel import Panel
@@ -26,6 +27,27 @@ from ari.core import build_runtime, generate_paper_section
 from ari.paths import PathManager
 from ari.pipeline import _extract_plan_sections
 
+
+def _load_repo_dotenv() -> None:
+    """Populate os.environ from ``$ARI_ROOT/.env`` if present.
+
+    Shell sessions often omit ``source .env``; Docker Compose loads it for Letta but
+    the ``ari`` CLI would otherwise stick to packaged ``workflow.yaml`` defaults
+    (e.g. openai/gpt-5.2).  ``override=False`` keeps explicit exports / wizard
+    settings authoritative.
+    """
+    root = Path(
+        os.environ.get(
+            "ARI_ROOT",
+            str(Path(__file__).resolve().parents[3]),
+        )
+    )
+    env_file = root / ".env"
+    if env_file.is_file():
+        load_dotenv(env_file, override=False)
+
+
+_load_repo_dotenv()
 
 # ---------------------------------------------------------------------------
 # lineage decision config + executor (extracted to ari.cli.lineage in Phase 3A)

--- a/ari-core/ari/cli/run.py
+++ b/ari-core/ari/cli/run.py
@@ -175,6 +175,20 @@ def run(
     from ari.orchestrator.node import Node
     import hashlib as _hl_run
 
+    experiment = experiment.expanduser()
+    if not experiment.is_file():
+        logging.getLogger(__name__).error("experiment path not found: %s", experiment.resolve())
+        typer.echo(
+            typer.style("File not found: ", fg=typer.colors.RED, bold=True)
+            + str(experiment)
+            + "\n\n"
+            + "Tip: bundled starter at examples/starter_experiment.md:\n"
+            + "       ari run examples/starter_experiment.md\n"
+            + "     Or copy it to experiment.md (see docs/experiment_file.md).\n",
+            err=True,
+        )
+        raise typer.Exit(1)
+
     experiment_text = experiment.read_text()
     # ── Trace: log experiment file as read from disk ────────────────
     _exp_hash = _hl_run.sha256(experiment_text.encode()).hexdigest()[:16]

--- a/ari-core/pyproject.toml
+++ b/ari-core/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic>=2.0",
     "typer>=0.12",
     "rich>=13.0",
+    "python-dotenv>=1.0",
     "pyyaml>=6.0",
     "paramiko>=3.0",
 ]

--- a/ari-skill-memory/src/server.py
+++ b/ari-skill-memory/src/server.py
@@ -7,9 +7,15 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 
 import nest_asyncio
-nest_asyncio.apply()
+
+# Python 3.14 + nest-asyncio patched event loops triggers anyio/asyncio glue that
+# can fail with AttributeError ('NoneType' has no attribute 'set_name') inside
+# mcp.run(); stdio FastMCP does not rely on nested loop patching on 3.14+.
+if sys.version_info < (3, 14):
+    nest_asyncio.apply()
 
 from mcp.server.fastmcp import FastMCP
 

--- a/docs/reference/environment_variables.md
+++ b/docs/reference/environment_variables.md
@@ -74,7 +74,7 @@ page is the alphabetical lookup.
 
 | Variable | Purpose |
 |---|---|
-| `ARI_MEMORY_BACKEND` | `letta` (default since v0.6) / `file` / `local` |
+| `ARI_MEMORY_BACKEND` | `letta` (default) or `in_memory` (no Letta required; ephemeral RAM-only backend for local smoke tests) |
 | `ARI_MEMORY_AUTO_RESTORE` | Auto-restore from `memory_backup.jsonl.gz` on resume |
 | `ARI_MEMORY_ACCESS_LOG` | Path to `memory_access.jsonl` |
 | `ARI_CURRENT_NODE_ID` | Set by the agent loop; skills read it but never set it |

--- a/examples/starter_experiment.md
+++ b/examples/starter_experiment.md
@@ -1,0 +1,20 @@
+# Starter experiment — copy or run as-is
+
+Copy to `experiment.md` (gitignored) for a local default, or run:
+
+`ari run examples/starter_experiment.md`
+
+**Letta を立てていない場合:** メモリ MCP は既定で Letta に繋ぎます。次のいずれかで回避できます。
+
+- 一時的: `export ARI_MEMORY_BACKEND=in_memory`（プロセス内のみ・永続化なし）
+- 永続化: `.env` に `ARI_MEMORY_BACKEND=in_memory` を追記
+
+Replace the goal and **Metrics** line with your real task. See `docs/experiment_file.md`.
+
+## Research Goal
+
+Sanity check: run a small ARI workflow end-to-end on this machine.
+
+## Metrics
+
+latency_ms

--- a/scripts/letta/docker-compose.yml
+++ b/scripts/letta/docker-compose.yml
@@ -1,6 +1,13 @@
 # Docker Compose deployment.
 # Brings up Letta + Postgres on a laptop/workstation. Managed by
 # `ari memory start-local` / `stop-local`.
+#
+# Postgres must ship pgvector (`VECTOR` type). Plain postgres:16-alpine
+# lacks it and Letta will crash migrating with:
+#   type "vector" does not exist
+# After changing DB image, reset volumes if migrations half-applied:
+#   docker compose -f scripts/letta/docker-compose.yml down -v
+#   docker compose -f scripts/letta/docker-compose.yml up -d
 services:
   letta:
     image: letta/letta:latest
@@ -17,18 +24,27 @@ services:
       LETTA_SERVER_PASS: "${LETTA_API_KEY:-}"
       LETTA_PG_URI: "postgresql://letta:letta@pg/letta"
     depends_on:
-      - pg
+      pg:
+        condition: service_healthy
     volumes:
       - letta-data:/app/letta
   pg:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     container_name: ari-letta-pg
     environment:
       POSTGRES_USER: letta
       POSTGRES_PASSWORD: letta
       POSTGRES_DB: letta
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U letta -d letta"]
+      interval: 3s
+      timeout: 5s
+      retries: 40
+      start_period: 30s
     volumes:
       - pg-data:/var/lib/postgresql/data
+      # First boot only — enables vector type before Letta migrations.
+      - ./pg-init:/docker-entrypoint-initdb.d:ro
 volumes:
   letta-data:
   pg-data:

--- a/scripts/letta/pg-init/01-vector.sql
+++ b/scripts/letta/pg-init/01-vector.sql
@@ -1,0 +1,4 @@
+-- Letta migrations create columns with embedding VECTOR(...) — Postgres needs
+-- the pgvector extension. This runs once on fresh volume init (official
+-- postgres/pgvector entrypoint loads /docker-entrypoint-initdb.d/*.sql).
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/scripts/setup/banner.sh
+++ b/scripts/setup/banner.sh
@@ -42,11 +42,19 @@ fi
 
 echo ""
 echo -e "${BOLD}  $(m next)${RESET}"
+
+# Prefer venv-installed console script — works even when ~/bin has no symlink.
+ARI_BIN="${ARI_ROOT}/.venv/bin/ari"
+
+# Prefer bundled starter when present (experiment.md itself is gitignored for user edits).
+ARI_STARTER="$ARI_ROOT/examples/starter_experiment.md"
+
 echo ""
 echo "  $(m next_model)"
 echo ""
 echo "     # 🐜 Ollama (free, local)"
-echo "     ollama pull qwen3:8b && ollama serve"
+echo "     ollama pull qwen3:8b"
+echo "     ollama serve   # omit if localhost:11434 already answers (daemon running)"
 echo "     export ARI_BACKEND=ollama ARI_MODEL=qwen3:8b"
 echo ""
 echo "     # 🐜 OpenAI (cloud API)"
@@ -56,16 +64,41 @@ echo "     # 🐜 Anthropic (cloud API)"
 echo "     export ARI_BACKEND=claude ARI_MODEL=anthropic/claude-sonnet-4-5 ANTHROPIC_API_KEY=sk-ant-..."
 echo ""
 echo "  $(m next_run)"
-echo "     ari run experiment.md"
+if [ -x "$ARI_BIN" ]; then
+  if [ -f "$ARI_STARTER" ]; then
+    echo "     \"$ARI_BIN\" run \"$ARI_STARTER\""
+  else
+    echo "     \"$ARI_BIN\" run experiment.md"
+  fi
+else
+  if [ -f "$ARI_STARTER" ]; then
+    echo "     ari run \"$ARI_STARTER\""
+  else
+    echo "     ari run experiment.md"
+  fi
+fi
+echo "     # or: \"$PYTHON\" -m ari.cli run <path-to-experiment.md>"
 echo ""
 echo "  $(m next_paper)"
-echo "     ari paper ./checkpoints/<run_id>/"
+if [ -x "$ARI_BIN" ]; then
+  echo "     \"$ARI_BIN\" paper ./checkpoints/<run_id>/"
+else
+  echo "     ari paper ./checkpoints/<run_id>/"
+fi
 echo ""
 echo "  $(m next_projects)"
-echo "     ari projects"
+if [ -x "$ARI_BIN" ]; then
+  echo "     \"$ARI_BIN\" projects"
+else
+  echo "     ari projects"
+fi
 echo ""
 echo "  $(m next_dash)"
-echo "     ari viz ./checkpoints/ --port 9886"
+if [ -x "$ARI_BIN" ]; then
+  echo "     \"$ARI_BIN\" viz ./checkpoints/ --port 9886"
+else
+  echo "     ari viz ./checkpoints/ --port 9886"
+fi
 echo "     # → http://localhost:9886 🐜"
 echo ""
 

--- a/scripts/setup/detect_env.sh
+++ b/scripts/setup/detect_env.sh
@@ -27,7 +27,7 @@ ok "$(m shell): $CURRENT_SHELL"
 PYTHON=""
 for candidate in python3 python; do
   if command -v "$candidate" &>/dev/null; then
-    ver=$("$candidate" --version 2>&1 | grep -oP '\d+\.\d+' | head -1)
+    ver=$("$candidate" --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
     major=$(echo "$ver" | cut -d. -f1)
     minor=$(echo "$ver" | cut -d. -f2)
     if [ "$major" -ge 3 ] && [ "$minor" -ge 10 ]; then
@@ -53,17 +53,34 @@ if [ -z "$PYTHON" ]; then
 fi
 ok "Python: $PYTHON ($($PYTHON --version 2>&1))"
 
-# --- Find pip (must match the detected Python) ------------------------------
+# --- Create / activate virtual environment ----------------------------------
+# PEP 668: Homebrew / externally-managed Python refuses pip installs outside a venv.
+VENV_DIR="$ARI_ROOT/.venv"
+if [ ! -f "$VENV_DIR/bin/python" ]; then
+  info "仮想環境を作成中: $VENV_DIR"
+  "$PYTHON" -m venv "$VENV_DIR" || {
+    fail "venv の作成に失敗しました: $VENV_DIR"
+    exit 1
+  }
+  ok "仮想環境を作成しました: $VENV_DIR"
+else
+  ok "仮想環境が見つかりました: $VENV_DIR"
+fi
+PYTHON="$VENV_DIR/bin/python"
+export PYTHON
+
+# --- Find pip (use venv pip directly) ---------------------------------------
 PIP=""
-# Prefer $PYTHON -m pip to guarantee pip matches the correct Python version
-if $PYTHON -m pip --version &>/dev/null 2>&1; then
+# venv always has pip; use it directly to avoid any system pip confusion
+if [ -f "$VENV_DIR/bin/pip" ]; then
+  PIP="$VENV_DIR/bin/pip"
+elif $PYTHON -m pip --version &>/dev/null 2>&1; then
   PIP="$PYTHON -m pip"
 else
   for candidate in pip3 pip; do
     if command -v "$candidate" &>/dev/null; then
-      # Verify this pip belongs to the same Python
-      pip_py_ver=$("$candidate" --version 2>&1 | grep -oP 'python \K\d+\.\d+' || echo "")
-      python_ver=$("$PYTHON" --version 2>&1 | grep -oP '\d+\.\d+' | head -1)
+      pip_py_ver=$("$candidate" --version 2>&1 | sed 's/.*python \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/' | grep -oE '^[0-9]+\.[0-9]+' || echo "")
+      python_ver=$("$PYTHON" --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
       if [ "$pip_py_ver" = "$python_ver" ]; then
         PIP="$candidate"
         break

--- a/scripts/setup/install_letta.sh
+++ b/scripts/setup/install_letta.sh
@@ -116,7 +116,7 @@ if [[ "${ARI_NONINTERACTIVE:-0}" != "1" ]] && [[ -t 0 ]]; then
   read -r PROMPT || PROMPT="y"
 fi
 PROMPT="${PROMPT:-y}"
-if [[ "${PROMPT,,}" == "n" ]]; then
+if [[ "$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]')" == "n" ]]; then
   warn "$(m_safe install_letta_skipped "Letta install deferred — run 'ari memory start-local' later.")"
   _env_append_if_absent "# ARI_MEMORY_BOOTSTRAP_LOCAL_LETTA=${ARI_DETECTED_LETTA_PATH}"
   return 0 2>/dev/null || exit 0
@@ -139,8 +139,8 @@ case "${ARI_DETECTED_LETTA_PATH}" in
     ;;
 esac
 
-# Poll for health.
-for _i in $(seq 1 30); do
+# Poll for health (PostgreSQL init on first boot can exceed 60 s on slower disks).
+for _i in $(seq 1 60); do
   if curl -fsS "${URL}/v1/health/" >/dev/null 2>&1 \
       || curl -fsS "${URL}/v1/health"  >/dev/null 2>&1; then
     ok "$(m_safe install_letta_up "Letta reachable at ${URL}")"
@@ -151,5 +151,5 @@ for _i in $(seq 1 30); do
   sleep 2
 done
 
-warn "$(m_safe install_letta_timeout "Letta not reachable after 60 s — retry with 'ari memory start-local'.")"
+warn "$(m_safe install_letta_timeout "Letta not reachable after 120 s — check: docker compose -f scripts/letta/docker-compose.yml logs letta pg  •  retry: ari memory start-local.")"
 _env_append_if_absent "# ARI_MEMORY_BOOTSTRAP_LOCAL_LETTA=${ARI_DETECTED_LETTA_PATH}"

--- a/scripts/setup/install_paperbench.sh
+++ b/scripts/setup/install_paperbench.sh
@@ -30,10 +30,35 @@ PB_ROOT="$ARI_ROOT/ari-skill-paper-re/vendor/paperbench"
 PB_PROJECT="$PB_ROOT/project/paperbench"
 COMMON_DIR="$PB_ROOT/project/common"
 
-# 1) Make sure the submodule is fetched.
+# 1) Make sure the submodule is fetched (and not incomplete).
+# An incomplete checkout (dir exists but pyproject.toml missing) happens when
+# git-lfs is absent and the smudge filter kills the checkout. Detect and retry.
+_pb_needs_checkout=0
 if [ ! -d "$PB_PROJECT" ]; then
+  _pb_needs_checkout=1
+elif [ ! -f "$PB_PROJECT/pyproject.toml" ]; then
+  warn "PaperBench checkout appears incomplete (pyproject.toml missing) — re-initialising"
+  ( cd "$ARI_ROOT" && git submodule deinit -f -- ari-skill-paper-re/vendor/paperbench 2>/dev/null || true )
+  _pb_needs_checkout=1
+fi
+
+if [ "$_pb_needs_checkout" -eq 1 ]; then
   if [ -f "$ARI_ROOT/.gitmodules" ] && grep -q "vendor/paperbench" "$ARI_ROOT/.gitmodules" 2>/dev/null; then
-    if ! ( cd "$ARI_ROOT" && git submodule update --init --depth 1 -- ari-skill-paper-re/vendor/paperbench ); then
+    # Without git-lfs, the upstream repo's filter.lfs.process still invokes
+    # `git-lfs filter-process` and checkout aborts. Override LFS filters for
+    # this command only (source + pointer files suffice for ORS).
+    _pb_git=(git)
+    if ! command -v git-lfs >/dev/null 2>&1; then
+      warn "git-lfs not found — skipping LFS file download (source-only checkout)"
+      _pb_git+=(
+        -c filter.lfs.smudge=
+        -c filter.lfs.clean=
+        -c filter.lfs.process=
+        -c filter.lfs.required=false
+      )
+      export GIT_LFS_SKIP_SMUDGE=1
+    fi
+    if ! ( cd "$ARI_ROOT" && "${_pb_git[@]}" submodule update --init --depth 1 -- ari-skill-paper-re/vendor/paperbench ); then
       fail "git submodule init failed for ari-skill-paper-re/vendor/paperbench"
       exit 1
     fi

--- a/scripts/setup/messages.sh
+++ b/scripts/setup/messages.sh
@@ -181,9 +181,9 @@ msg_import_fail_en="import failed"
 msg_import_fail_ja="インポート失敗"
 msg_import_fail_zh="导入失败"
 
-msg_cli_not_in_path_en="'ari' not in PATH — add ~/.local/bin:"
-msg_cli_not_in_path_ja="'ari' が PATH にありません — ~/.local/bin を追加:"
-msg_cli_not_in_path_zh="'ari' 不在 PATH 中 — 请添加 ~/.local/bin:"
+msg_cli_not_in_path_en="'ari' not on PATH — add this repo's venv:"
+msg_cli_not_in_path_ja="'ari' が PATH にありません — リポジトリの .venv を PATH に:"
+msg_cli_not_in_path_zh="'ari' 不在 PATH 中 — 请将仓库的 .venv 加入 PATH:"
 
 msg_cli_fail_en="ari CLI not found"
 msg_cli_fail_ja="ari CLI が見つかりません"

--- a/scripts/setup/setup_env.sh
+++ b/scripts/setup/setup_env.sh
@@ -373,7 +373,7 @@ _env_append_if_absent "# ARI_TRANSFORM_MEMORY_MAX_CHARS=2000"
 _env_append_if_absent "# ARI_REACT_MEMORY_SEARCH_LIMIT=10"
 _env_append_if_absent "# ARI_REACT_MEMORY_MAX_ENTRY_CHARS=0"
 # Internal / tests only — do not set unless you know why:
-_env_append_if_absent "# ARI_MEMORY_BACKEND=letta  # letta | in_memory (test fake)"
+_env_append_if_absent "# ARI_MEMORY_BACKEND=letta  # letta | in_memory — use in_memory if Letta is not running"
 _env_append_if_absent "# ARI_MEMORY_LETTA_DISABLE_SELF_EDIT=true"
 _env_append_if_absent "# ARI_MEMORY_ACCESS_LOG=on"
 _env_append_if_absent "# ARI_MEMORY_AUTO_RESTORE=true"

--- a/scripts/setup/spinner.sh
+++ b/scripts/setup/spinner.sh
@@ -145,7 +145,12 @@ _colony_messages_zh=(
 
 colony_say() {
   local lang="${SETUP_LANG:-en}"
-  local -n msgs="_colony_messages_${lang}"
-  local idx=$(( RANDOM % ${#msgs[@]} ))
-  echo -e "  ${CYAN}🐜💬${RESET} ${msgs[$idx]}"
+  local arr_name="_colony_messages_${lang}"
+  # Use eval to support Bash 3.2 (macOS default) which lacks nameref (local -n)
+  local len
+  eval "len=\${#${arr_name}[@]}"
+  local idx=$(( RANDOM % len ))
+  local msg
+  eval "msg=\${${arr_name}[$idx]}"
+  echo -e "  ${CYAN}🐜💬${RESET} ${msg}"
 }

--- a/scripts/setup/verify.sh
+++ b/scripts/setup/verify.sh
@@ -23,7 +23,8 @@ if command -v ari &>/dev/null; then
 elif $PYTHON -m ari.cli --help &>/dev/null 2>&1; then
   ok "ari CLI: $PYTHON -m ari.cli ✔"
   warn "$(m cli_not_in_path)"
-  echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+  echo "    export PATH=\"\$ARI_ROOT/.venv/bin:\$PATH\""
+  echo "    # pip install --user の場合のみ: export PATH=\"\$HOME/.local/bin:\$PATH\""
 else
   fail "$(m cli_fail)"
   ERRORS=$((ERRORS + 1))


### PR DESCRIPTION
## 背景

ローカルの Mac（Homebrew の Python・zsh 環境）で ARI のクイックスタートで、セットアップ周りや Letta/docker、CLI の設定読み込みでコケるポイントがいくつか出たので、Cursor上でガチャガチャ試してクイックスタートのプロセスを起動することができた環境を共有するためのPR。最適化とかではないし、別に実験とか論文生成はまだ行ってない

## 何を変えたか

### セットアップ系スクリプト（`scripts/setup/`）

- **BSD `grep` / 古めの Bash**：GNU 専用オプション（例: `-P`）や Bash 4+ 前提の記法を避け、macOS のデフォルト環境でも通るように調整。
- **PEP 668（externally-managed-environment）**：プロジェクト直下の **`.venv`** を前提にするなど、`pip install` がすぐ詰まらないように案内・検出を合わせる。
- **`install_paperbench` / submodule**：**`git-lfs` が無いマシン**でも、チェックアウトが進むようにフィルタ周りを抑止する経路を入れる（LFS が必須の別対応とは切り分けつつ）。
- **メッセージ・バナー**：PATH ヒントなどを **`$ARI_ROOT/.venv/bin`** に寄せ、`ari` が見つからない系のハマりを減らす。
- **`install_letta`**：ヘルス待ち時間の延長など、コンテナ warming で早めに諦める状況を減らす。

### Letta / Docker Compose（`scripts/letta/`）

- Postgres を **pgvector** 系イメージにし、初期化 SQL で **`vector` 拡張** を入れる（Letta が VECTOR 前提の構成でコケる問題の回避）。
- **`pg` の healthcheck + `depends_on`（healthy）`** で、`letta` が DB 準備前に立ち上がりすぎるレースを減らす。

### ARI CLI / コア（`ari-core`）

- **リポジトリ直下の `$ARI_ROOT/.env` を起動時に読み込む**（`python-dotenv`）。  
  「Docker Compose は `.env` を読むのに、`ari run` は読まなくて **`workflow.yaml` のデフォルト（例: OpenAI / モデル名）が効いてしまう**」というずれを減らすため。**既にシェルで export 済みの変数は上書きしない**（`override=False`）。
- **`ari run`** で実験ファイルが無いとき、**ヒントメッセージ**（starter のパスなど）を出すようにして初回を迷わせないようにする。
- **`python-dotenv` を依存に追加**。

### メモリ skill（`ari-skill-memory`）

- **Python 3.14** 環境で、**`nest_asyncio.apply()` と FastMCP/anyio の組み合わせがクラッシュすることがあったため**、**3.14 以上では `nest_asyncio` を適用しない**ガードを入れた（stdio サーバ経路での回避）。←

### ドキュメント / スターター

- **`ARI_MEMORY_BACKEND` の説明**を現在の選択肢と整合させる。
- **`examples/starter_experiment.md`** を同梱し、すぐに一回回すための入口を用意してみた

## なぜそう変更したか

| 問題点 | 対応 |
|---|---|
| Mac の標準ツールと Linux 想定スクリプトのズレる | スクリプト側を「標準より古い／BSD でも動く」寄りに寄せる |
| `.env` を `source` し忘れるとYAML設定と矛盾する | CLI 側で **リポジトリの `.env` をベストエフォートで読む** |
| Letta が DB 側の VECTOR で落ちる / 起動が競合する | **pgvector + 拡張 + healthcheck** |
| Python 3.14 で memory MCP が落ちる | **nest-asyncio を条件付きに** |
| 初回ユーザーがファイル名で止まる | **starter とメッセージ** |